### PR TITLE
fixing regression introduced in 595e589099ac3d945f53b0a737f590f748ac99e4

### DIFF
--- a/explode.py
+++ b/explode.py
@@ -411,8 +411,10 @@ def Expand(pWork):
             source_offset = pWork.outputPos - minus_dist
 
             #  Copy the repeating sequence
-            pWork.out_buff[target_offset:target_offset + rep_length] = \
-                pWork.out_buff[source_offset:source_offset+ rep_length]
+            for i in range(rep_length):
+                pWork.out_buff[target_offset] = pWork.out_buff[source_offset]
+                target_offset += 1
+                source_offset += 1
 
             #  Update buffer output position
             pWork.outputPos += rep_length
@@ -434,10 +436,11 @@ def Expand(pWork):
             #  within decompressed part of the output buffer.
             target_offset = 0
             source_offset = 0x1000
-            copy_length = pWork.outputPos - 0x1000
 
-            pWork.out_buff[target_offset:target_offset + copy_length] = \
-                pWork.out_buff[source_offset:source_offset+ copy_length]
+            for i in range(pWork.outputPos - 0x1000):
+                pWork.out_buff[target_offset] = pWork.out_buff[source_offset]
+                target_offset += 1
+                source_offset += 1
 
             pWork.outputPos -= 0x1000
 


### PR DESCRIPTION
Commit 595e589099ac3d945f53b0a737f590f748ac99e4 has introduced a regression where numerous NUL bytes were introduced in the output stream of the decompressed files.

This was because the array slice assignment was not equivalent to the loop item assignments when the array ranges were overlapping. reverting that change fixes the output.

Verified by running the following code:

```
import mpyq

archive = mpyq.MPQArchive('d2data.mpq') # from a fresh install of Diablo II LoD 1.14d
f = [f for f in archive.files if 'misc.txt' in f.decode('ascii')][0]

with open('misc.txt', 'wb') as o:
    o.write(archive.read_file(f))
```